### PR TITLE
wget 대신에 HTTP::Tiny 를 사용

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{ $dist->name }}
 
 {{ $NEXT }}
+    - Remove `wget` fetching, use only HTTP::Tiny
+    - Save content as decoded data
 
 0.003     2015-02-02 10:53:40+09:00 Asia/Seoul
     - Encode content as UTF-8 when fetching via HTTP::Tiny

--- a/lib/Parcel/Track/KR/CJKorea.pm
+++ b/lib/Parcel/Track/KR/CJKorea.pm
@@ -132,10 +132,10 @@ __END__
     # ID & URI
     print $tracker->id . "\n";
     print $tracker->uri . "\n";
-    
+
     # Track the information
     my $result = $tracker->track;
-    
+
     # Get the information what you want.
     if ( $result ) {
         print "Message sent ok\n";

--- a/lib/Parcel/Track/KR/CJKorea.pm
+++ b/lib/Parcel/Track/KR/CJKorea.pm
@@ -9,7 +9,6 @@ our $VERSION = '0.004';
 
 with 'Parcel::Track::Role::Base';
 
-use Capture::Tiny;
 use Encode;
 use File::Which;
 use HTML::Selector::XPath;
@@ -21,7 +20,6 @@ use HTTP::Tiny;
 #
 use IO::Socket::SSL;
 use Mozilla::CA;
-use Net::SSLeay;
 
 our $URI =
     'https://www.doortodoor.co.kr/parcel/doortodoor.do?fsp_action=PARC_ACT_002&fsp_cmd=retrieveInvNoACT&invc_no=%s';


### PR DESCRIPTION
https://www.doortodoor.co.kr/parcel/doortodoor.do?fsp_action=PARC_ACT_002&fsp_cmd=retrieveInvNoACT&invc_no=202148842334

서비스가 SSL v2 를 더이상 사용하지 않기 때문에 `wget` 대신에 `HTTP::Tiny` 를 사용하도록 수정하였습니다.
- 결과를 perl 내부 자료로써 다루기 위해 decode 된 데이터를 가지도록 하였습니다.
