### PR TITLE
Prevent undefined error when there are no query results

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{ $dist->name }}
 
 {{ $NEXT }}
+    - Prevent undefined error when there are no query results.
 
 0.004     2016-02-18 17:10:56+09:00 Asia/Seoul
     - Remove `wget` fetching, use only HTTP::Tiny

--- a/lib/Parcel/Track/KR/CJKorea.pm
+++ b/lib/Parcel/Track/KR/CJKorea.pm
@@ -106,9 +106,10 @@ sub track {
         next if $row_index++ == 0;
 
         my @tds = $e->look_down( '_tag', 'td' );
-        push @{ $result{descs} }, join( q{ }, map $_->as_text, @tds[ 1, 0, 3, 2 ] );
+        push @{ $result{descs} },
+            join( q{ }, map { $_ ? $_->as_text : '' } @tds[ 1, 0, 3, 2 ] );
 
-        $result{result} = join( q{ }, map $_->as_text, @tds[ 1, 0 ] );
+        $result{result} = join( q{ }, map { $_ ? $_->as_text : '' } @tds[ 1, 0 ] );
     }
 
     return \%result;

--- a/lib/Parcel/Track/KR/CJKorea.pm
+++ b/lib/Parcel/Track/KR/CJKorea.pm
@@ -90,7 +90,7 @@ sub track {
 
     my $found      = ( $tree->findnodes("$prefix/div[2]/div/table/tr[2]/td") )[0];
     my $found_text = $found ? $found->as_text : q{};
-    my $not_found  = Encode::encode_utf8('조회된 데이터가 없습니다');
+    my $not_found  = '조회된 데이터가 없습니다';
     if ( $found_text =~ m/$not_found/ ) {
         $result{result} = 'cannot find such parcel info';
         return \%result;

--- a/lib/Parcel/Track/KR/CJKorea.pm
+++ b/lib/Parcel/Track/KR/CJKorea.pm
@@ -106,10 +106,9 @@ sub track {
         next if $row_index++ == 0;
 
         my @tds = $e->look_down( '_tag', 'td' );
-        push @{ $result{descs} },
-            join( q{ }, map { $_ ? $_->as_text : '' } @tds[ 1, 0, 3, 2 ] );
+        push @{ $result{descs} }, join( q{ }, map $_->as_text, @tds[ 1, 0, 3, 2 ] );
 
-        $result{result} = join( q{ }, map { $_ ? $_->as_text : '' } @tds[ 1, 0 ] );
+        $result{result} = join( q{ }, map $_->as_text, @tds[ 1, 0 ] );
     }
 
     return \%result;

--- a/t/01_not_found.t
+++ b/t/01_not_found.t
@@ -1,0 +1,14 @@
+use strict;
+use warnings;
+use Test::More tests => 3;
+
+use_ok 'Parcel::Track';
+
+my ( $tracker, $result );
+$tracker = Parcel::Track->new( 'KR::CJKorea', '697569448283' );
+$result = $tracker->track;
+ok( $result->{result}, 'exists' );
+
+$tracker = Parcel::Track->new( 'KR::CJKorea', '697569448283xxxxx' );
+$result = $tracker->track;
+ok( $result->{result}, 'not found' );

--- a/t/01_not_found.t
+++ b/t/01_not_found.t
@@ -9,6 +9,7 @@ $tracker = Parcel::Track->new( 'KR::CJKorea', '697569448283' );
 $result = $tracker->track;
 ok( $result->{result}, 'exists' );
 
-$tracker = Parcel::Track->new( 'KR::CJKorea', '697569448283xxxxx' );
+$tracker = Parcel::Track->new( 'KR::CJKorea', '697569448284' );
 $result = $tracker->track;
-ok( $result->{result}, 'not found' );
+is( $result->{result}, 'cannot find such parcel info', 'not found' );
+


### PR DESCRIPTION
#2 

조회결과가 없을때, `$_->as_text` `$_` 가 undefined 인데 `->text` 메소드를 사용하려해서 에러가 발생합니다.
이문제를 해결하는 PR 입니다.